### PR TITLE
Remove version from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   postgres:
     image: postgres


### PR DESCRIPTION
> time="2026-06-26T15:02:31Z" level=warning msg="/home/runner/work/slick-testkit-example/slick-testkit-example/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"